### PR TITLE
Change iframe width to match with the content

### DIFF
--- a/app/popup/index.html
+++ b/app/popup/index.html
@@ -7,7 +7,7 @@
       margin: 0;
     }
     iframe {
-      width: 24em;
+      width: 370px;
       height: 15em;
       border: none;
     }


### PR DESCRIPTION
Hotel `<aside>` have min-width of 365px, and today it is creating a vertical scroll.

![screenshot from 2016-10-25 16 09 39](https://cloud.githubusercontent.com/assets/3277185/19698300/7ef6f670-9acd-11e6-8ff3-9dd60c106800.png)

Changing iframe to 370px width fit perfect into window.
